### PR TITLE
Update Jenkinsfile to use Jenkins shared library

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,21 +56,6 @@ def get_macos_pipeline() {
           checkout scm
         }  // stage
 
-        stage("macOS: Conan setup") {
-          withCredentials([
-            string(
-              credentialsId: 'local-conan-server-password',
-              variable: 'CONAN_PASSWORD'
-            )
-          ]) {
-            sh "conan user \
-              --password '${CONAN_PASSWORD}' \
-              --remote ${conan_remote} \
-              ${conan_user} \
-              > /dev/null"
-          }  // withCredentials
-        }  // stage
-
         stage("macOS: Package") {
           sh "conan create . ${conan_user}/${conan_pkg_channel} \
             --settings h5cpp:build_type=Release \
@@ -81,19 +66,7 @@ def get_macos_pipeline() {
             --build=outdated"
 
           sh "conan info ."
-
-          // pkg_name_and_version = sh(
-          //   script: "./get_conan_pkg_name_and_version.sh",
-          //   returnStdout: true
-          // ).trim()
         }  // stage
-
-        // stage("macOS: Upload") {
-        //   sh "conan upload \
-        //     --all \
-        //     --remote ${conan_remote} \
-        //     ${pkg_name_and_version}@${conan_user}/${conan_pkg_channel}"
-        // }  // stage
       }  // dir
     }  // node
   }  // return
@@ -104,41 +77,20 @@ def get_win10_pipeline() {
     node('windows10') {
       // Use custom location to avoid Win32 path length issues
       ws('c:\\jenkins\\') {
-      cleanWs()
-      dir("${project}") {
-        stage("win10: Checkout") {
-          checkout scm
-        }  // stage
+        cleanWs()
+        dir("${project}") {
+          stage("win10: Checkout") {
+            checkout scm
+          }  // stage
 
-        // stage("win10: Conan setup") {
-        //   withCredentials([
-        //     string(
-        //       credentialsId: 'local-conan-server-password',
-        //       variable: 'CONAN_PASSWORD'
-        //     )
-        //   ]) {
-        //     bat """C:\\Users\\dmgroup\\AppData\\Local\\Programs\\Python\\Python36\\Scripts\\conan.exe user \
-        //       --password ${CONAN_PASSWORD} \
-        //       --remote ${conan_remote} \
-        //       ${conan_user}"""
-        //   }  // withCredentials
-        // }  // stage
-
-        stage("win10: Package") {
-          bat """C:\\Users\\dmgroup\\AppData\\Local\\Programs\\Python\\Python36\\Scripts\\conan.exe \
-            create . ${conan_user}/${conan_pkg_channel} \
-            --settings h5cpp:build_type=Release \
-            --build=outdated"""
-        }  // stage
-
-        // stage("win10: Upload") {
-        //   sh "upload_conan_package.sh conanfile.py \
-        //     ${conan_remote} \
-        //     ${conan_user} \
-        //     ${conan_pkg_channel}"
-        // }  // stage
-      }  // dir
-      }
+          stage("win10: Package") {
+            bat """C:\\Users\\dmgroup\\AppData\\Local\\Programs\\Python\\Python36\\Scripts\\conan.exe \
+              create . ${conan_user}/${conan_pkg_channel} \
+              --settings h5cpp:build_type=Release \
+              --build=outdated"""
+          }  // stage
+        }  // dir
+      }  // ws
     }  // node
   }  // return
 } // def

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,174 +1,51 @@
+@Library('ecdc-pipeline')
+import ecdcpipeline.ContainerBuildNode
+import ecdcpipeline.ConanPackageBuilder
+
 project = "conan-h5cpp"
 
 conan_remote = "ess-dmsc-local"
 conan_user = "ess-dmsc"
 conan_pkg_channel = "testing"
 
-remote_upload_node = "centos7"
-
-images = [
-        'centos7': [
-                'name': 'essdmscdm/centos7-build-node:4.0.0',
-                'sh': '/usr/bin/scl enable devtoolset-6 -- /bin/bash -e'
-        ],
-        'debian9': [
-                'name': 'essdmscdm/debian9-build-node:3.0.0',
-                'sh': 'bash -e'
-        ],
-        'ubuntu1804': [
-                'name': 'essdmscdm/ubuntu18.04-build-node:2.0.0',
-                'sh': 'bash -e'
-        ]
+container_build_nodes = [
+  'centos': ContainerBuildNode.getDefaultContainerBuildNode('centos7'),
+  'debian': ContainerBuildNode.getDefaultContainerBuildNode('debian9'),
+  'ubuntu': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu1804')
 ]
 
-base_container_name = "${project}-${env.BRANCH_NAME}-${env.BUILD_NUMBER}"
+package_builder = new ConanPackageBuilder(this, container_build_nodes, conan_pkg_channel)
+package_builder.defineRemoteUploadNode('centos')
 
-if (conan_pkg_channel == "stable") {
-  if (env.BRANCH_NAME != "master") {
-    error("Only the master branch can create a package for the stable channel")
+builders = package_builder.createPackageBuilders { container ->
+  package_builder.addConfiguration(container, [
+    'settings': [
+      'h5cpp:build_type': 'Release'
+    ]
+  ])
+
+  package_builder.addConfiguration(container, [
+    'settings': [
+      'h5cpp:build_type': 'Debug'
+    ]
+  ])
+
+  // Build parallel libraries only on CentOS.
+  if (container.key == 'centos') {
+    package_builder.addConfiguration(container, [
+      'settings': [
+        'h5cpp:build_type': 'Release'
+      ],
+      'options': [
+        'h5cpp:parallel': "True"
+      ],
+      'env': [
+        'CC': '/usr/lib64/mpich-3.2/bin/mpicc',
+        'CXX': '/usr/lib64/mpich-3.2/bin/mpic++'
+      ]
+    ])
   }
-  conan_upload_flag = "--no-overwrite"
-} else {
-  conan_upload_flag = ""
 }
-
-def get_pipeline(image_key) {
-  return {
-    node('docker') {
-      def container_name = "${base_container_name}-${image_key}"
-      try {
-        def image = docker.image(images[image_key]['name'])
-        def custom_sh = images[image_key]['sh']
-        def container = image.run("\
-          --name ${container_name} \
-          --tty \
-          --cpus=2 \
-          --memory=4GB \
-          --network=host \
-          --env http_proxy=${env.http_proxy} \
-          --env https_proxy=${env.https_proxy} \
-          --env local_conan_server=${env.local_conan_server} \
-        ")
-
-        stage("${image_key}: Checkout") {
-          sh """docker exec ${container_name} ${custom_sh} -c \"
-            git clone \
-              --branch ${env.BRANCH_NAME} \
-              https://github.com/ess-dmsc/${project}.git
-          \""""
-        }  // stage
-
-        stage("${image_key}: Conan setup") {
-          withCredentials([
-            string(
-              credentialsId: 'local-conan-server-password',
-              variable: 'CONAN_PASSWORD'
-            )
-          ]) {
-            sh """docker exec ${container_name} ${custom_sh} -c \"
-              set +x
-              conan remote add \
-                --insert 0 \
-                ${conan_remote} ${local_conan_server}
-              conan user \
-                --password '${CONAN_PASSWORD}' \
-                --remote ${conan_remote} \
-                ${conan_user} \
-                > /dev/null
-            \""""
-          }  // withCredentials
-        }  // stage
-
-        stage("${image_key}: Package") {
-          sh """docker exec ${container_name} ${custom_sh} -c \"
-            cd ${project}
-            conan create . ${conan_user}/${conan_pkg_channel} \
-              --settings h5cpp:build_type=Release \
-              --build=outdated
-          \""""
-
-          sh """docker exec ${container_name} ${custom_sh} -c \"
-            cd ${project}
-            conan create . ${conan_user}/${conan_pkg_channel} \
-              --settings h5cpp:build_type=Debug \
-              --build=outdated
-          \""""
-
-          // Build parallel libraries only on CentOS.
-          if (['centos7'].contains(image_key)) {
-            sh """docker exec ${container_name} ${custom_sh} -c \"
-              cd ${project}
-              CC=/usr/lib64/mpich-3.2/bin/mpicc \
-              CXX=/usr/lib64/mpich-3.2/bin/mpic++ \
-              conan create . ${conan_user}/${conan_pkg_channel} \
-                --settings h5cpp:build_type=Release \
-                --options h5cpp:parallel=True \
-                --build=outdated
-            \""""
-            sh """docker exec ${container_name} ${custom_sh} -c \"
-              cd ${project}
-              conan info .
-            \""""
-          }  // if
-
-          // Use shell script to avoid escaping issues
-          pkg_name_and_version = sh(
-            script: """docker exec ${container_name} ${custom_sh} -c \"
-                cd ${project}
-                ./get_conan_pkg_name_and_version.sh
-              \"""",
-            returnStdout: true
-          ).trim()
-
-        }  // stage
-
-        stage("${image_key}: Local upload") {
-          sh """docker exec ${container_name} ${custom_sh} -c \"
-            conan upload \
-              --all \
-              ${conan_upload_flag} \
-              --remote ${conan_remote} \
-              ${pkg_name_and_version}@${conan_user}/${conan_pkg_channel}
-          \""""
-        }  // stage
-
-        // Upload to remote repository only once
-        if (image_key == remote_upload_node) {
-          stage("${image_key}: Remote upload") {
-            withCredentials([
-              usernamePassword(
-                credentialsId: 'cow-bot-bintray-username-and-api-key',
-                passwordVariable: 'COWBOT_PASSWORD',
-                usernameVariable: 'COWBOT_USERNAME'
-              )
-            ]) {
-              sh """docker exec ${container_name} ${custom_sh} -c \"
-                set +x
-                conan user \
-                  --password '${COWBOT_PASSWORD}' \
-                  --remote ess-dmsc \
-                  ${COWBOT_USERNAME} \
-                  > /dev/null
-              \""""
-            }  // withCredentials
-
-            sh """docker exec ${container_name} ${custom_sh} -c \"
-              conan upload \
-                ${conan_upload_flag} \
-                --remote ess-dmsc \
-                ${pkg_name_and_version}@${conan_user}/${conan_pkg_channel}
-            \""""
-          }  // stage
-        }  // if
-
-      } finally {
-        sh "docker stop ${container_name}"
-        sh "docker rm -f ${container_name}"
-	cleanWs()
-      }  // finally
-    }  // node
-  }  // return
-}  // def
 
 def get_macos_pipeline() {
   return {
@@ -205,19 +82,18 @@ def get_macos_pipeline() {
 
           sh "conan info ."
 
-          pkg_name_and_version = sh(
-            script: "./get_conan_pkg_name_and_version.sh",
-            returnStdout: true
-          ).trim()
+          // pkg_name_and_version = sh(
+          //   script: "./get_conan_pkg_name_and_version.sh",
+          //   returnStdout: true
+          // ).trim()
         }  // stage
 
-        stage("macOS: Upload") {
-          sh "conan upload \
-            --all \
-            ${conan_upload_flag} \
-            --remote ${conan_remote} \
-            ${pkg_name_and_version}@${conan_user}/${conan_pkg_channel}"
-        }  // stage
+        // stage("macOS: Upload") {
+        //   sh "conan upload \
+        //     --all \
+        //     --remote ${conan_remote} \
+        //     ${pkg_name_and_version}@${conan_user}/${conan_pkg_channel}"
+        // }  // stage
       }  // dir
     }  // node
   }  // return
@@ -255,12 +131,12 @@ def get_win10_pipeline() {
             --build=outdated"""
         }  // stage
 
-        stage("win10: Upload") {
-          //sh "upload_conan_package.sh conanfile.py \
-          //  ${conan_remote} \
-           // ${conan_user} \
-           // ${conan_pkg_channel}"
-        }  // stage
+        // stage("win10: Upload") {
+        //   sh "upload_conan_package.sh conanfile.py \
+        //     ${conan_remote} \
+        //     ${conan_user} \
+        //     ${conan_pkg_channel}"
+        // }  // stage
       }  // dir
       }
     }  // node
@@ -277,8 +153,10 @@ node {
   }
   builders['macOS'] = get_macos_pipeline()
   builders['windows10'] = get_win10_pipeline()
-  parallel builders
 
-  // Delete workspace when build is done.
-  cleanWs()
+  try {
+    parallel builders
+  } finally {
+    cleanWs()
+  }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,19 +110,19 @@ def get_win10_pipeline() {
           checkout scm
         }  // stage
 
-        stage("win10: Conan setup") {
-          withCredentials([
-            string(
-              credentialsId: 'local-conan-server-password',
-              variable: 'CONAN_PASSWORD'
-            )
-          ]) {
-            bat """C:\\Users\\dmgroup\\AppData\\Local\\Programs\\Python\\Python36\\Scripts\\conan.exe user \
-              --password ${CONAN_PASSWORD} \
-              --remote ${conan_remote} \
-              ${conan_user}"""
-          }  // withCredentials
-        }  // stage
+        // stage("win10: Conan setup") {
+        //   withCredentials([
+        //     string(
+        //       credentialsId: 'local-conan-server-password',
+        //       variable: 'CONAN_PASSWORD'
+        //     )
+        //   ]) {
+        //     bat """C:\\Users\\dmgroup\\AppData\\Local\\Programs\\Python\\Python36\\Scripts\\conan.exe user \
+        //       --password ${CONAN_PASSWORD} \
+        //       --remote ${conan_remote} \
+        //       ${conan_user}"""
+        //   }  // withCredentials
+        // }  // stage
 
         stage("win10: Package") {
           bat """C:\\Users\\dmgroup\\AppData\\Local\\Programs\\Python\\Python36\\Scripts\\conan.exe \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -146,11 +146,6 @@ def get_win10_pipeline() {
 node {
   checkout scm
 
-  def builders = [:]
-  for (x in images.keySet()) {
-    def image_key = x
-    builders[image_key] = get_pipeline(image_key)
-  }
   builders['macOS'] = get_macos_pipeline()
   builders['windows10'] = get_win10_pipeline()
 


### PR DESCRIPTION
This makes the Jenkinsfile shorter and cleaner. I removed the upload steps for macOS and Windows, as we only have one node of each and packages are kept in the local cache,