### PR TITLE
Add option to go boostless and use as default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,9 +8,9 @@ conan_user = "ess-dmsc"
 conan_pkg_channel = "stable"
 
 container_build_nodes = [
-  'centos': ContainerBuildNode.getDefaultContainerBuildNode('centos7'),
-  'debian': ContainerBuildNode.getDefaultContainerBuildNode('debian9'),
-  'ubuntu': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu1804')
+  'centos': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),
+  'debian': ContainerBuildNode.getDefaultContainerBuildNode('debian10'),
+  'ubuntu': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu1804-gcc8')
 ]
 
 package_builder = new ConanPackageBuilder(this, container_build_nodes, conan_pkg_channel)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,12 +20,36 @@ builders = package_builder.createPackageBuilders { container ->
   package_builder.addConfiguration(container, [
     'settings': [
       'h5cpp:build_type': 'Release'
+    ],
+    'options': [
+      'h5cpp:with_boost': 'True'
     ]
   ])
 
   package_builder.addConfiguration(container, [
     'settings': [
       'h5cpp:build_type': 'Debug'
+    ],
+    'options': [
+      'h5cpp:with_boost': 'True'
+    ]
+  ])
+  
+  package_builder.addConfiguration(container, [
+    'settings': [
+      'h5cpp:build_type': 'Release'
+    ],
+    'options': [
+      'h5cpp:with_boost': 'False'
+    ]
+  ])
+
+  package_builder.addConfiguration(container, [
+    'settings': [
+      'h5cpp:build_type': 'Debug'
+    ],
+    'options': [
+      'h5cpp:with_boost': 'False'
     ]
   ])
 
@@ -58,10 +82,22 @@ def get_macos_pipeline() {
         stage("macOS: Package") {
           sh "conan create . ${conan_user}/${conan_pkg_channel} \
             --settings h5cpp:build_type=Release \
+            --options h5cpp:with_boost=False \
             --build=outdated"
 
           sh "conan create . ${conan_user}/${conan_pkg_channel} \
             --settings h5cpp:build_type=Debug \
+            --options h5cpp:with_boost=False \
+            --build=outdated"
+            
+          sh "conan create . ${conan_user}/${conan_pkg_channel} \
+            --settings h5cpp:build_type=Release \
+            --options h5cpp:with_boost=True \
+            --build=outdated"
+
+          sh "conan create . ${conan_user}/${conan_pkg_channel} \
+            --settings h5cpp:build_type=Debug \
+            --options h5cpp:with_boost=True \
             --build=outdated"
 
           sh "conan info ."
@@ -86,6 +122,13 @@ def get_win10_pipeline() {
             bat """C:\\Users\\dmgroup\\AppData\\Local\\Programs\\Python\\Python36\\Scripts\\conan.exe \
               create . ${conan_user}/${conan_pkg_channel} \
               --settings h5cpp:build_type=Release \
+              --options h5cpp:with_boost=True \
+              --build=outdated"""
+              
+            bat """C:\\Users\\dmgroup\\AppData\\Local\\Programs\\Python\\Python36\\Scripts\\conan.exe \
+              create . ${conan_user}/${conan_pkg_channel} \
+              --settings h5cpp:build_type=Release \
+              --options h5cpp:with_boost=False \
               --build=outdated"""
           }  // stage
         }  // dir

--- a/conanfile.py
+++ b/conanfile.py
@@ -23,7 +23,7 @@ class H5cppConan(ConanFile):
     archive_sha256 = "2ccae670109d605a2c26729abd2b1a98b0b5a7fe5dd98df5f03c5fe76463e1e7"
     
     # Test package
-    commit = "2cfb0ad"
+    commit = "897cec0"
     #version = commit
 
     name = "h5cpp"
@@ -36,12 +36,11 @@ class H5cppConan(ConanFile):
     description = "h5cpp wrapper"
     settings = "os", "compiler", "build_type", "arch"
     requires = (
-        "cmake_findboost_modular/1.69.0@bincrafters/stable",
-        "boost_filesystem/1.69.0@bincrafters/stable",
         "hdf5/1.10.5-dm2@ess-dmsc/stable"
     )
     options = {
-        "parallel": [True, False]
+        "parallel": [True, False],
+        "with_boost": [True, False]
     }
     
     # The temporary build diirectory
@@ -49,6 +48,7 @@ class H5cppConan(ConanFile):
 
     default_options = (
         "parallel=False",
+        "with_boost=False",
         "boost_filesystem:shared=True",
         "boost_system:shared=True",
         "hdf5:shared=True",
@@ -74,6 +74,10 @@ class H5cppConan(ConanFile):
             self.options['hdf5'].parallel = True
         else:
             self.options['hdf5'].parallel = False
+            
+        if self.options.with_boost:
+            self.requires("cmake_findboost_modular/1.69.0@bincrafters/stable")
+            self.requires("boost_filesystem/1.69.0@bincrafters/stable")
 
     def build(self):
         # Workaround to find the Conan-installed version of Boost on systems
@@ -95,6 +99,11 @@ class H5cppConan(ConanFile):
             cmake.definitions["CMAKE_INSTALL_PREFIX"] = ""
             cmake.definitions["CONAN"] = "MANUAL"
             cmake.definitions["DISABLE_TESTS"] = "ON"
+            
+            if self.options.with_boost:
+                cmake.definitions["WITH_BOOST"] = "ON"
+            else:
+                cmake.definitions["WITH_BOOST"] = "OFF"
 
             if self.options.parallel:
                 cmake.definitions["WITH_MPI"] = "ON"

--- a/conanfile.py
+++ b/conanfile.py
@@ -23,7 +23,7 @@ class H5cppConan(ConanFile):
     archive_sha256 = "2ccae670109d605a2c26729abd2b1a98b0b5a7fe5dd98df5f03c5fe76463e1e7"
     
     # Test package
-    commit = "897cec0"
+    commit = "dc5aeda"
     #version = commit
 
     name = "h5cpp"

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,6 +1,12 @@
 project(h5cpp-example LANGUAGES CXX C)
 cmake_minimum_required(VERSION 2.8.12)
-set(CMAKE_CXX_STANDARD 11)
+
+set(WITH_BOOST OFF CACHE BOOL "Require Boost for filesystem support")
+if (WITH_BOOST)
+  set(CMAKE_CXX_STANDARD 11)
+else()
+  set(CMAKE_CXX_STANDARD 17)
+endif()
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(KEEP_RPATHS)
@@ -11,7 +17,6 @@ if (WIN32)
   target_link_libraries(example
   PRIVATE ${CONAN_LIBS})
 else()
-  find_package(Boost COMPONENTS filesystem system REQUIRED)
   find_package(h5cpp REQUIRED)
   target_link_libraries(example
   PRIVATE h5cpp)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -2,13 +2,24 @@ from conans import ConanFile, CMake, tools, RunEnvironment
 import os
 
 
-class GtestTestConan(ConanFile):
+class H5cppTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    requires = "cmake_installer/3.10.0@conan/stable"
+    options = {
+        "with_boost": [True, False]
+    }
+    default_options = (
+        "with_boost=False"
+    )
 
     def build(self):
         cmake = CMake(self)
+        
+        if self.options.with_boost:
+            cmake.definitions["WITH_BOOST"] = "ON"
+        else:
+            cmake.definitions["WITH_BOOST"] = "OFF"
+                
         # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is
         # in "test_package".
         cmake.configure(source_dir=self.source_folder, build_dir="./")

--- a/test_package/example.cpp
+++ b/test_package/example.cpp
@@ -32,7 +32,8 @@ using data_type = std::vector<int>;
 
 int main()
 {
-  file::File f = file::create("writing_vector2.h5",file::AccessFlags::TRUNCATE);
+  std::string const Filename = "writing_vector2.h5";
+  file::File f = file::create(Filename, file::AccessFlags::TRUNCATE);
   node::Group root_group = f.root();
 
   data_type data{1,2,3,4};


### PR DESCRIPTION
I added the option to build h5cpp with `std::filesystem` or `std::experimental::filesystem` instead of boost: https://github.com/ess-dmsc/h5cpp/pull/444
This change updates our conan recipe to expose the option. The option is set to `False` (build without boost) by default, both options are built on Jenkins on each platform.