### PR TITLE
changed channel to testing and bumped lib version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ import ecdcpipeline.ConanPackageBuilder
 project = "conan-h5cpp"
 
 conan_user = "ess-dmsc"
-conan_pkg_channel = "testing"
+conan_pkg_channel = "stable"
 
 container_build_nodes = [
   'centos': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,12 +5,12 @@ import ecdcpipeline.ConanPackageBuilder
 project = "conan-h5cpp"
 
 conan_user = "ess-dmsc"
-conan_pkg_channel = "stable"
+conan_pkg_channel = "testing"
 
 container_build_nodes = [
   'centos': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),
-  'debian': ContainerBuildNode.getDefaultContainerBuildNode('debian10'),
-  'ubuntu': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu1804-gcc8')
+  'debian10': ContainerBuildNode.getDefaultContainerBuildNode('debian10'),
+  'ubuntu2004': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2004')
 ]
 
 package_builder = new ConanPackageBuilder(this, container_build_nodes, conan_pkg_channel)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ There are 2 ways of doing this, depending on whether you want to create a packag
   * Download the *\*tar.gz* from the [h5cpp release page](https://github.com/ess-dmsc/h5cpp/releases) and generate the SHA-256 checksum for the file: `sha256sum v0.x.y.tar.gz` or `shasum -a 256 v0.x.y.tar.gz`. Make sure that it is the *\*tar.gz* version of the file that you create the checksum for.
   * In [conanfile.py](conanfile.py), set `archive_sha256` to the new checksum.
 * steps **only** for arbitrary commits:
-    * In [conanfile.py](conanfile.py), set `package_type` to "test".
+    * In [conanfile.py](conanfile.py), set `package_type` to "development".
     * In [conanfile.py](conanfile.py), set `commit` to the commit hash (first 7 hex letters) of the commit that you want to package
 * push and massage until the job succeeds on [Jenkins](https://jenkins.esss.dk/dm/job/ess-dmsc/job/conan-h5cpp/)
 * ideally, test new version of package with actual projects that use it

--- a/conanfile.py
+++ b/conanfile.py
@@ -19,9 +19,9 @@ def source_release(version, sha_string):
 class H5cppConan(ConanFile):
     package_type = "release"
     # Release (stable) pacakge
-    version_number = "0.4.0"
-    version = version_number + "-dm2"
-    archive_sha256 = "333cd97308dcf969a98308c296ab206cb1958dee298e456a72ce078c4fd65470"
+    version_number = "0.4.1"
+    version = version_number + "" #append -dm1, -dm2, ... when only recipe gets updated
+    archive_sha256 = "dd0833619fc9ef615829cfcbfaeca0694f27b3c1ca573633ee103e4c7aa92ebb"
     
     # Test package
     commit = "dc5aeda"

--- a/conanfile.py
+++ b/conanfile.py
@@ -17,7 +17,8 @@ def source_release(version, sha_string):
     os.remove(archive_name)
 
 class H5cppConan(ConanFile):
-    package_type = "release"
+    package_type = "release" # "release" or "development"
+
     # Release (stable) package
     # The following lines are used if `package_type` above was set to "release"
     version_number = "0.4.1"

--- a/conanfile.py
+++ b/conanfile.py
@@ -36,7 +36,7 @@ class H5cppConan(ConanFile):
     description = "h5cpp wrapper"
     settings = "os", "compiler", "build_type", "arch"
     requires = (
-        "hdf5/1.10.5-dm3@ess-dmsc/stable"
+        "hdf5/1.12.1@ess-dmsc/stable"
     )
     options = {
         "parallel": [True, False],

--- a/conanfile.py
+++ b/conanfile.py
@@ -18,17 +18,20 @@ def source_release(version, sha_string):
 
 class H5cppConan(ConanFile):
     package_type = "release"
-    # Release (stable) pacakge
+    # Release (stable) package
+    # The following lines are used if `package_type` above was set to "release"
     version_number = "0.4.1"
-    version = version_number + "" #append -dm1, -dm2, ... when only recipe gets updated
+    version_suffix = "" #use "-dm1", "-dm2", etc.. when only the recipe gets updated
+    version = version_number + version_suffix
     archive_sha256 = "dd0833619fc9ef615829cfcbfaeca0694f27b3c1ca573633ee103e4c7aa92ebb"
     
-    # Test package
+    # Development package
+    # The following is used if `package_type` above was set to "development"
     commit = "dc5aeda"
 
     name = "h5cpp"
     folder_name = "h5cpp-{}".format(version_number)
-    if package_type == "test":
+    if package_type == "development":
         version = commit
         folder_name = name
     license = "LGPL 2.1"
@@ -59,7 +62,7 @@ class H5cppConan(ConanFile):
     def source(self):
         if self.package_type == "release":
             source_release(self.version_number, self.archive_sha256)
-        elif self.package_type == "test":
+        elif self.package_type == "development":
             self.source_git(self.commit)
             self.folder_name = "h5cpp"
         else:


### PR DESCRIPTION
* Updated Ubuntu image in Jenkins job
* Bumped version to 0.4.1
* Added some comments in `conanfile.py` to explain the version tag logic
* `package_type` is either "release" or "development" so it is less confused with `channel` in jenkinsfile
* Updated README:
  * link to Jenkins job
  * short intro on how to use package
  * more streamlined recipe updating instructions with focus on CI