### PR TITLE
ECDC-3154: Release new version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,22 +52,6 @@ builders = package_builder.createPackageBuilders { container ->
       'h5cpp:with_boost': 'False'
     ]
   ])
-
-  // Build parallel libraries only on CentOS.
-  if (container.key == 'centos') {
-    package_builder.addConfiguration(container, [
-      'settings': [
-        'h5cpp:build_type': 'Release'
-      ],
-      'options': [
-        'h5cpp:parallel': "True"
-      ],
-      'env': [
-        'CC': '/usr/lib64/mpich-3.2/bin/mpicc',
-        'CXX': '/usr/lib64/mpich-3.2/bin/mpic++'
-      ]
-    ])
-  }
 }
 
 def get_macos_pipeline() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,8 @@ conan_pkg_channel = "testing"
 
 container_build_nodes = [
   'centos': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11'),
-  'debian10': ContainerBuildNode.getDefaultContainerBuildNode('debian11'),
-  'ubuntu2004': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2204')
+  'debian': ContainerBuildNode.getDefaultContainerBuildNode('debian11'),
+  'ubuntu': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2204')
 ]
 
 package_builder = new ConanPackageBuilder(this, container_build_nodes, conan_pkg_channel)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,12 +5,12 @@ import ecdcpipeline.ConanPackageBuilder
 project = "conan-h5cpp"
 
 conan_user = "ess-dmsc"
-conan_pkg_channel = "stable"
+conan_pkg_channel = "testing"
 
 container_build_nodes = [
-  'centos': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),
-  'debian10': ContainerBuildNode.getDefaultContainerBuildNode('debian10'),
-  'ubuntu2004': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2004')
+  'centos': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11'),
+  'debian10': ContainerBuildNode.getDefaultContainerBuildNode('debian11'),
+  'ubuntu2004': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2204')
 ]
 
 package_builder = new ConanPackageBuilder(this, container_build_nodes, conan_pkg_channel)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ import ecdcpipeline.ConanPackageBuilder
 project = "conan-h5cpp"
 
 conan_user = "ess-dmsc"
-conan_pkg_channel = "testing"
+conan_pkg_channel = "stable"
 
 container_build_nodes = [
   'centos': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11'),

--- a/conanfile.py
+++ b/conanfile.py
@@ -37,7 +37,6 @@ class H5cppConan(ConanFile):
 
     def source(self):
         self.source_git(self.commit)
-        self.folder_name = "h5cpp"
 
     def source_git(self, commit):
         self.run("git clone https://github.com/ess-dmsc/h5cpp.git")
@@ -91,8 +90,10 @@ class H5cppConan(ConanFile):
             )
 
     def package(self):
+        folder_name = "h5cpp"
+
         # Copy headers
-        src_path = os.path.join(self.folder_name, "src")
+        src_path = os.path.join(folder_name, "src")
         self.copy(pattern="*.hpp", dst="include", src=src_path, keep_path=True)
 
         if tools.os_info.is_windows:
@@ -106,7 +107,7 @@ class H5cppConan(ConanFile):
             self.copy(pattern="*.pdb", dst="bin", src=self.build_dir+"/install", keep_path=False)
 
         # Copy license
-        self.copy("LICENSE.*", src=self.folder_name)
+        self.copy("LICENSE.*", src=folder_name)
 
     def package_info(self):
         self.cpp_info.libs = ["h5cpp"]

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -17,8 +17,7 @@ if (WIN32)
   target_link_libraries(example
   PRIVATE ${CONAN_LIBS})
 else()
-  find_package(hdf5 REQUIRED)
   find_package(h5cpp REQUIRED)
   target_link_libraries(example
-  PRIVATE h5cpp::h5cpp hdf5::hdf5)
+  PRIVATE h5cpp::h5cpp)
 endif()

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class H5cppTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake, cmake_find_package"
+    generators = "cmake", "cmake_find_package"
     options = {
         "with_boost": [True, False]
     }

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class H5cppTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake, cmake_find_package"
     options = {
         "with_boost": [True, False]
     }


### PR DESCRIPTION
Replace HDF5 with the version available from ConanCenter, and update build node versions.